### PR TITLE
Add log when demangling is complete

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,5 +31,6 @@ def demangle_swift(bv):
 	assert len(swift_variables) == len(results)
 	for (variable, name) in zip(swift_variables, results):
 		variable.name = name
+	binaryninja.log_info(f"Swift demangling complete! Updated {len(swift_functions)} functions and {len(swift_variables)} variables.")
 
 binaryninja.PluginCommand.register("Swift Demangler", "Demangles Swift", demangle_swift)


### PR DESCRIPTION
I'm not sure if there's any difference between `print()` and `log_info()` but I saw `log_info()` in an official plugin so went for that. I'm also not sure if there's a better way to indicate that the process is complete but at the moment there isn't any real indication and it's hard to tell if it's complete or not.