### PR TITLE
Demangle functions starting with `$s`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ def run_demanger(symbols):
 def demangle_swift(bv):
 	swift_functions = []
 	for function in bv.functions:
-		if function.name.startswith("_$s"):
+		if function.name.startswith("_$s") or function.name.startswith("$s"):
 			swift_functions.append(function)
 	results = run_demanger(map(lambda f: f.name, swift_functions))
 	assert len(swift_functions) == len(results)
@@ -23,7 +23,7 @@ def demangle_swift(bv):
 	for variable in variables:
 		try:
 			variable = variables[variable]
-			if variable.name.startswith("_$s"):
+			if variable.name.startswith("_$s") or function.name.startswith("$s"):
 				swift_variables.append(variable)
 		except:
 			pass


### PR DESCRIPTION
I noticed there were still some functions that were mangled and this patch seems to work but based on this not being included originally this might need to be tested.